### PR TITLE
Enable Nav2 exploration with front cone scan filter

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,18 @@ services:
         serial_baudrate:=${LIDAR_BAUDRATE:-1000000}
         serial_port:=/dev/ttyUSB1
 
+  scan_filter:
+    build:
+      context: ./scan_filter
+    depends_on:
+      rplidar: { condition: service_healthy }
+    network_mode: "service:navigation"
+    command: >
+      ros2 run scan_filter front_cone.py
+        center_deg:=${CENTER_DEG:-106.0}
+        fov_deg:=${FOV_DEG:-120.0}
+    restart: unless-stopped
+
   navigation:
     image: husarion/navigation2:humble-1.1.12-20240123
     restart: unless-stopped
@@ -38,14 +50,17 @@ services:
         map:=/maps/map.yaml
         use_sim_time:=False
 
-  explorer:
-    image: husarion/navigation2:humble-1.1.12-20240123
-    restart: unless-stopped
+  explore_lite:
+    image: husarion/explore_lite:humble
+    network_mode: "service:navigation"
     depends_on:
       navigation: { condition: service_started }
-    volumes:
-      - ./scripts:/scripts:ro
-    command: python3 /scripts/random_explorer.py
+    command: >
+      ros2 launch explore_lite explore.launch.py
+        planner_frequency:=1.0
+        visualize:=true
+        progress_timeout:=60.0
+    restart: unless-stopped
 
   foxglove:
     image: husarion/foxglove:1.84.0

--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -232,17 +232,13 @@ local_costmap:
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan
-          max_obstacle_height: 2.0
+        observation_sources: front
+        front:
+          topic: /scan_front
+          sensor_type: LaserScan
+          obstacle_max_range: 4.0
+          raytrace_max_range: 6.0
           clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 3.0

--- a/config/nav2_dwb_webots_params.yaml
+++ b/config/nav2_dwb_webots_params.yaml
@@ -232,17 +232,13 @@ local_costmap:
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+        observation_sources: front
+        front:
+          topic: /scan_front
+          sensor_type: LaserScan
+          obstacle_max_range: 4.0
+          raytrace_max_range: 6.0
           clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 3.0

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -249,17 +249,13 @@ local_costmap:
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+        observation_sources: front
+        front:
+          topic: /scan_front
+          sensor_type: LaserScan
+          obstacle_max_range: 4.0
+          raytrace_max_range: 6.0
           clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true

--- a/config/nav2_mppi_webots_params.yaml
+++ b/config/nav2_mppi_webots_params.yaml
@@ -250,17 +250,13 @@ local_costmap:
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+        observation_sources: front
+        front:
+          topic: /scan_front
+          sensor_type: LaserScan
+          obstacle_max_range: 4.0
+          raytrace_max_range: 6.0
           clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true

--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -220,17 +220,13 @@ local_costmap:
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+        observation_sources: front
+        front:
+          topic: /scan_front
+          sensor_type: LaserScan
+          obstacle_max_range: 4.0
+          raytrace_max_range: 6.0
           clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true

--- a/config/nav2_rpp_webots_params.yaml
+++ b/config/nav2_rpp_webots_params.yaml
@@ -220,17 +220,13 @@ local_costmap:
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+        observation_sources: front
+        front:
+          topic: /scan_front
+          sensor_type: LaserScan
+          obstacle_max_range: 4.0
+          raytrace_max_range: 6.0
           clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true

--- a/scan_filter/Dockerfile
+++ b/scan_filter/Dockerfile
@@ -1,0 +1,6 @@
+FROM ros:humble
+RUN apt-get update && apt-get install -y python3-numpy
+WORKDIR /scan_filter
+COPY front_cone.py .
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+CMD ["ros2","run","scan_filter","front_cone.py"]

--- a/scan_filter/front_cone.py
+++ b/scan_filter/front_cone.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import rclpy, math, numpy as np
+from rclpy.node import Node
+from sensor_msgs.msg import LaserScan
+
+class FrontCone(Node):
+    def __init__(self):
+        super().__init__('scan_front_filter')
+        self.declare_parameter('center_deg', 106.0)
+        self.declare_parameter('fov_deg', 120.0)
+        self.pub = self.create_publisher(LaserScan, '/scan_front', 10)
+        self.create_subscription(LaserScan, '/scan', self.cb, 10)
+
+    def cb(self, msg):
+        c = math.radians(self.get_parameter('center_deg').value)
+        h = math.radians(self.get_parameter('fov_deg').value / 2)
+        n = len(msg.ranges)
+        a = np.linspace(msg.angle_min, msg.angle_max, n, dtype=np.float32)
+        rel = ((a + math.pi) % (2 * math.pi) - math.pi) - c
+        rel = (rel + math.pi) % (2 * math.pi) - math.pi
+        mask = np.abs(rel) <= h
+
+        out = LaserScan()
+        out.header = msg.header
+        out.angle_min = -h
+        out.angle_max = +h
+        out.angle_increment = msg.angle_increment
+        out.time_increment = msg.time_increment
+        out.scan_time = msg.scan_time
+        out.range_min = msg.range_min
+        out.range_max = msg.range_max
+        out.ranges = np.asarray(msg.ranges)[mask].tolist()
+        self.pub.publish(out)
+
+def main():
+    rclpy.init(); rclpy.spin(FrontCone()); rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `scan_filter` with `front_cone.py` filter and Dockerfile
- point Nav2 local costmap to `/scan_front`
- add `scan_filter` and `explore_lite` services
- remove `random_explorer` service

## Testing
- `pre-commit` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_684bfbce94ec8323bf7155536165ee8f