### PR TITLE
Fix compose image for explore_lite

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -53,7 +53,7 @@ services:
 
   explore_lite:
 
-    image: husarion/explore_lite:humble
+    image: husarion/explore-lite:humble
     network_mode: "service:navigation"
     depends_on:
       navigation: { condition: service_started }


### PR DESCRIPTION
## Summary
- fix explore_lite Docker image name in `compose.yaml`

## Testing
- `pre-commit` *(fails: unable to download hooks)*

------
https://chatgpt.com/codex/tasks/task_e_684c0f27ad108323931bd9c0c03b522f