### PR TITLE
Fix explore_lite build

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ driver at 1,000,000&nbsp;baud.
     # or "just rosbot"
     ```
 
-    If this is your first run, build the scan filter image:
+    If this is your first run, build the scan filter and exploration images:
 
     ```bash
-    docker compose build scan_filter
+    docker compose build scan_filter explore_lite
     ```
 
    The launch starts a front-cone LIDAR filter and the `explore_lite`

--- a/compose.yaml
+++ b/compose.yaml
@@ -52,8 +52,8 @@ services:
         use_sim_time:=False
 
   explore_lite:
-
-    image: husarion/explore-lite:humble
+    build:
+      context: ./explore_lite
     network_mode: "service:navigation"
     depends_on:
       navigation: { condition: service_started }

--- a/explore_lite/Dockerfile
+++ b/explore_lite/Dockerfile
@@ -1,0 +1,5 @@
+FROM ros:humble
+RUN apt-get update && apt-get install -y ros-humble-explore-lite \
+    && rm -rf /var/lib/apt/lists/*
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+CMD ["ros2", "launch", "explore_lite", "explore.launch.py"]


### PR DESCRIPTION
## Summary
- build explore_lite from local Dockerfile instead of pulling unavailable image
- adjust README build instructions
- add explore_lite Dockerfile

## Testing
- `pre-commit run --files compose.yaml explore_lite/Dockerfile README.md` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_684c102f62d88323a61987b8c09161cf