### PR TITLE
Use prebuilt explore_lite image

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,11 @@ driver at 1,000,000&nbsp;baud.
     # or "just rosbot"
     ```
 
-    If this is your first run, build the scan filter and exploration images:
+   If this is your first run, build the scan filter image:
 
-    ```bash
-    docker compose build scan_filter explore_lite
-    ```
-
-   The launch starts a front-cone LIDAR filter and the `explore_lite`
-   planner. The filter publishes `/scan_front` for Nav2's local
-   costmap, while `explore_lite` drives the robot autonomously.
-
+   ```bash
+   docker compose build scan_filter
+   ```
 
    The launch starts a front-cone LIDAR filter and the `explore_lite`
    planner. The filter publishes `/scan_front` for Nav2's local

--- a/compose.yaml
+++ b/compose.yaml
@@ -52,8 +52,7 @@ services:
         use_sim_time:=False
 
   explore_lite:
-    build:
-      context: ./explore_lite
+    image: husarion/explore_lite:humble
     network_mode: "service:navigation"
     depends_on:
       navigation: { condition: service_started }

--- a/explore_lite/Dockerfile
+++ b/explore_lite/Dockerfile
@@ -1,5 +1,0 @@
-FROM ros:humble
-RUN apt-get update && apt-get install -y ros-humble-explore-lite \
-    && rm -rf /var/lib/apt/lists/*
-ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-CMD ["ros2", "launch", "explore_lite", "explore.launch.py"]


### PR DESCRIPTION
## Summary
- delete custom `explore_lite` Dockerfile
- pull `husarion/explore_lite:humble` image in compose file
- update docs to reflect new build step

## Testing
- `pre-commit run --files compose.yaml README.md` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c118333048323a24e33922baeefa9