### PR TITLE
Fix explore_lite image

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -52,7 +52,7 @@ services:
         use_sim_time:=False
 
   explore_lite:
-    image: husarion/explore_lite:humble
+    image: ghcr.io/ros-planning/explore_lite:humble
     network_mode: "service:navigation"
     depends_on:
       navigation: { condition: service_started }


### PR DESCRIPTION
## Summary
- fix the image for the `explore_lite` service to use the official repository

## Testing
- `pre-commit run --files compose.yaml` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_684c173dca9483238ce2576da8237989