### PR TITLE
Fix explore_lite build context

### DIFF
--- a/explore_lite/Dockerfile
+++ b/explore_lite/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
 
 # 2. Workspace
 WORKDIR /ws
-COPY ../explore_lite_src ./src
+COPY explore_lite_src ./src
 
 RUN . /opt/ros/humble/setup.sh && \
     colcon build --symlink-install && \

--- a/explore_lite/explore_lite_src/README.md
+++ b/explore_lite/explore_lite_src/README.md
@@ -5,5 +5,5 @@ This directory should contain the source code of the
 Clone the repository here before building the Docker image:
 
 ```bash
-git clone https://github.com/ros-planning/explore_lite.git explore_lite_src
+git clone https://github.com/ros-planning/explore_lite.git explore_lite/explore_lite_src
 ```


### PR DESCRIPTION
## Summary
- move `explore_lite_src` into `explore_lite` so the Docker build context contains the source
- adjust Dockerfile to copy from the new path
- update README path

## Testing
- `docker compose build explore_lite` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c196e9c70832399e20cf75c0b7388