### PR TITLE
Fix ROS apt key setup

### DIFF
--- a/explore_lite/Dockerfile
+++ b/explore_lite/Dockerfile
@@ -1,6 +1,15 @@
 # Use the same base as the Nav2 container
 FROM husarion/navigation2:humble-1.1.12-20240123
 
+# --- parche clave GPG ROS 2 ---
+RUN apt-get update && apt-get install -y curl gnupg2 lsb-release && \
+    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | \
+        gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+          http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+          > /etc/apt/sources.list.d/ros2.list
+# ------------------------------
+
 # 1. Additional build-time dependencies
 RUN apt-get update && apt-get install -y \
     ros-humble-navigation2-msgs \

--- a/scan_filter/Dockerfile
+++ b/scan_filter/Dockerfile
@@ -1,4 +1,14 @@
 FROM ros:humble
+
+# --- parche clave GPG ROS 2 ---
+RUN apt-get update && apt-get install -y curl gnupg2 lsb-release && \
+    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | \
+        gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+          http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+          > /etc/apt/sources.list.d/ros2.list
+# ------------------------------
+
 RUN apt-get update && apt-get install -y python3-numpy
 WORKDIR /scan_filter
 COPY front_cone.py .


### PR DESCRIPTION
## Summary
- fix apt key setup for ROS in scan_filter Dockerfile
- fix apt key setup for ROS in explore_lite Dockerfile

## Testing
- `pre-commit run --files explore_lite/Dockerfile scan_filter/Dockerfile` *(fails: unable to fetch from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_684c28be12008323803e9bf0b6681a9e