### PR TITLE
Fix Docker key refresh

### DIFF
--- a/explore_lite/Dockerfile
+++ b/explore_lite/Dockerfile
@@ -1,14 +1,15 @@
 # Use the same base as the Nav2 container
 FROM husarion/navigation2:humble-1.1.12-20240123
 
-# --- refresco de clave ROS2 2024-06 ---
-RUN sed -i 's|^deb .*packages.ros.org.*|# &|' /etc/apt/sources.list.d/ros2.list && \
-    apt-get update && apt-get install -y curl gnupg2 lsb-release && \
+# --- refresh ROS 2 key and repo list ---
+RUN set -e ; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl gnupg2 lsb-release ; \
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
-        | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+        | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
     echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
          http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
-         > /etc/apt/sources.list.d/ros2.list && \
+         > /etc/apt/sources.list.d/ros2.list ; \
     apt-get update
 # --------------------------------------
 

--- a/scan_filter/Dockerfile
+++ b/scan_filter/Dockerfile
@@ -1,13 +1,14 @@
 FROM ros:humble
 
-# --- refresco de clave ROS2 2024-06 ---
-RUN sed -i 's|^deb .*packages.ros.org.*|# &|' /etc/apt/sources.list.d/ros2.list && \
-    apt-get update && apt-get install -y curl gnupg2 lsb-release && \
+# --- refresh ROS 2 key and repo list ---
+RUN set -e ; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl gnupg2 lsb-release ; \
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
-        | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+        | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
     echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
          http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
-         > /etc/apt/sources.list.d/ros2.list && \
+         > /etc/apt/sources.list.d/ros2.list ; \
     apt-get update
 # --------------------------------------
 


### PR DESCRIPTION
## Summary
- fix Docker build by fetching new ROS 2 key and repository list for explore_lite
- do the same for scan_filter

## Testing
- `pre-commit run -a` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_684c2b7b8ab88323bbcc3f4c15714c69