### PR TITLE
Fix ROS 2 apt key in Dockerfiles

### DIFF
--- a/explore_lite/Dockerfile
+++ b/explore_lite/Dockerfile
@@ -1,20 +1,19 @@
 # Use the same base as the Nav2 container
 FROM husarion/navigation2:humble-1.1.12-20240123
 
-# --- refresh ROS 2 key and repo list ---
+# ---------- PARCHE: clave nueva para packages.ros.org (jun-2024) ----------
 RUN set -e ; \
-    apt-get update && apt-get install -y --no-install-recommends \
-        curl gnupg2 lsb-release ; \
+    rm -f /etc/apt/sources.list.d/ros2-*.list ; \
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
         | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
     echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
-         http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
-         > /etc/apt/sources.list.d/ros2.list ; \
+http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+        > /etc/apt/sources.list.d/ros2.list ; \
     apt-get update
-# --------------------------------------
+# --------------------------------------------------------------------------
 
 # 1. Additional build-time dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get install -y --no-install-recommends \
     ros-humble-navigation2-msgs \
  && rm -rf /var/lib/apt/lists/*
 

--- a/scan_filter/Dockerfile
+++ b/scan_filter/Dockerfile
@@ -1,18 +1,17 @@
 FROM ros:humble
 
-# --- refresh ROS 2 key and repo list ---
+# ---------- PARCHE: clave nueva para packages.ros.org (jun-2024) ----------
 RUN set -e ; \
-    apt-get update && apt-get install -y --no-install-recommends \
-        curl gnupg2 lsb-release ; \
+    rm -f /etc/apt/sources.list.d/ros2-*.list ; \
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
         | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
     echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
-         http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
-         > /etc/apt/sources.list.d/ros2.list ; \
+http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+        > /etc/apt/sources.list.d/ros2.list ; \
     apt-get update
-# --------------------------------------
+# --------------------------------------------------------------------------
 
-RUN apt-get update && apt-get install -y python3-numpy
+RUN apt-get install -y python3-numpy
 WORKDIR /scan_filter
 COPY front_cone.py .
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp


### PR DESCRIPTION
## Summary
- refresh GPG key and repository definition for ROS 2
- drop redundant `apt-get update` during package install

## Testing
- `pre-commit run -a` *(fails: unable to fetch pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_684c2dd5b6dc8323a8523f238a66ab6e