### PR TITLE
Remove duplicate ROS2 keyring setup from Dockerfiles

### DIFF
--- a/explore_lite/Dockerfile
+++ b/explore_lite/Dockerfile
@@ -1,16 +1,6 @@
 # Use the same base as the Nav2 container
 FROM husarion/navigation2:humble-1.1.12-20240123
 
-# ---------- PARCHE: clave nueva para packages.ros.org (jun-2024) ----------
-RUN set -e ; \
-    rm -f /etc/apt/sources.list.d/ros2-*.list ; \
-    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
-        | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
-    echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
-http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
-        > /etc/apt/sources.list.d/ros2.list ; \
-    apt-get update
-# --------------------------------------------------------------------------
 
 # 1. Additional build-time dependencies
 RUN apt-get install -y --no-install-recommends \

--- a/scan_filter/Dockerfile
+++ b/scan_filter/Dockerfile
@@ -1,15 +1,5 @@
 FROM ros:humble
 
-# ---------- PARCHE: clave nueva para packages.ros.org (jun-2024) ----------
-RUN set -e ; \
-    rm -f /etc/apt/sources.list.d/ros2-*.list ; \
-    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
-        | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
-    echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
-http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
-        > /etc/apt/sources.list.d/ros2.list ; \
-    apt-get update
-# --------------------------------------------------------------------------
 
 RUN apt-get install -y python3-numpy
 WORKDIR /scan_filter


### PR DESCRIPTION
## Summary
- drop the custom ROS keyring setup from explore_lite Dockerfile
- drop the same keyring patch from scan_filter Dockerfile

## Testing
- `pre-commit run -a` *(fails: unable to fetch hooks due to network restrictions)*
- `docker compose build explore_lite scan_filter` *(fails: `docker` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c2f91d59c83238125c8d67a3ba7f7