### PR TITLE
Update scan_filter Dockerfile and compose service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,8 @@ services:
   scan_filter:
     build: ./scan_filter
     network_mode: "service:navigation"   # comparte DDS
+    depends_on:
+      rplidar: { condition: service_healthy }
     # ⬇️  ya NO hace falta ningún 'command': lo marca ENTRYPOINT
     restart: unless-stopped
 

--- a/scan_filter/Dockerfile
+++ b/scan_filter/Dockerfile
@@ -1,10 +1,8 @@
-FROM ros:humble
-
-RUN apt-get update && apt-get install -y python3-numpy && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /opt/scan_filter
+FROM ros:humble-ros-base
+WORKDIR /scan_filter
 COPY front_cone.py .
 
-# Execute the filter directly without `ros2 run`
-ENTRYPOINT ["python3", "/opt/scan_filter/front_cone.py", "--ros-args"]
+ENTRYPOINT ["python3", "-u", "front_cone.py",
+            "--center_deg", "106",
+            "--fov_deg", "120"]
 


### PR DESCRIPTION
## Summary
- update `scan_filter/Dockerfile` to use ros-base and pass args directly
- ensure `scan_filter` service in `compose.yaml` depends on `rplidar`

## Testing
- `pre-commit run --files scan_filter/Dockerfile compose.yaml` *(failed: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c3d4b70ec8323b0291da0a2f6ada7