### PR TITLE
Fix scan_filter package install

### DIFF
--- a/docker/scan_filter/Dockerfile
+++ b/docker/scan_filter/Dockerfile
@@ -12,5 +12,7 @@ WORKDIR /ws
 RUN . /opt/ros/humble/setup.sh && \
     colcon build --symlink-install
 
+ENV ROS_WS=/ws
+
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["ros2", "run", "scan_filter", "front_cone"]

--- a/ws/src/scan_filter/resource/scan_filter__front_cone
+++ b/ws/src/scan_filter/resource/scan_filter__front_cone
@@ -1,0 +1,1 @@
+front_cone

--- a/ws/src/scan_filter/setup.py
+++ b/ws/src/scan_filter/setup.py
@@ -1,3 +1,24 @@
 from setuptools import setup
+import os
 
-setup()
+package_name = 'scan_filter'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=[package_name],
+    data_files=[
+        (os.path.join('share/ament_index/resource_index/packages'),
+         ['resource/scan_filter']),
+        (os.path.join('share/ament_index/resource_index/ros2_executable'),
+         ['resource/scan_filter__front_cone']),
+        (os.path.join('share', package_name), ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    entry_points={
+        'console_scripts': [
+            'front_cone = scan_filter.front_cone:main',
+        ],
+    },
+)


### PR DESCRIPTION
## Summary
- ensure `scan_filter` gets indexed by ament
- add ROS_WS env var for scan_filter container

## Testing
- `python3 -m py_compile ws/src/scan_filter/scan_filter/front_cone.py`
- `colcon build --packages-select scan_filter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851746625f483238ff02c57f5b2980f