### PR TITLE
Fix scan_filter container

### DIFF
--- a/docker/explore_lite/Dockerfile
+++ b/docker/explore_lite/Dockerfile
@@ -13,6 +13,8 @@ RUN . /opt/ros/humble/setup.sh && \
     rm -rf /root/.colcon/ ~/.cache && \
     apt-get clean
 
-ENTRYPOINT ["/ros_entrypoint.sh"]
+ENV ROS_WS=/ws
+COPY docker/ros_ws_entrypoint.sh /ros_ws_entrypoint.sh
+ENTRYPOINT ["/ros_ws_entrypoint.sh"]
 CMD ["ros2", "launch", "explore_lite", "explore.launch.py", \
      "planner_frequency:=1.0", "visualize:=true", "progress_timeout:=60.0"]

--- a/docker/ros_ws_entrypoint.sh
+++ b/docker/ros_ws_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+source /opt/ros/$ROS_DISTRO/setup.bash
+if [ -n "$ROS_WS" ] && [ -f "$ROS_WS/install/setup.bash" ]; then
+  source "$ROS_WS/install/setup.bash"
+fi
+exec "$@"

--- a/docker/scan_filter/Dockerfile
+++ b/docker/scan_filter/Dockerfile
@@ -14,5 +14,6 @@ RUN . /opt/ros/humble/setup.sh && \
 
 ENV ROS_WS=/ws
 
-ENTRYPOINT ["/ros_entrypoint.sh"]
+COPY docker/ros_ws_entrypoint.sh /ros_ws_entrypoint.sh
+ENTRYPOINT ["/ros_ws_entrypoint.sh"]
 CMD ["ros2", "run", "scan_filter", "front_cone"]


### PR DESCRIPTION
## Summary
- add custom entrypoint that sources built workspace
- fix Dockerfiles to use the entrypoint and set ROS_WS

## Testing
- `python3 -m compileall -q ws/src/scan_filter ws/src/explore_lite`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851776ccad483238ced5b758faddf2b