### PR TITLE
Fix ROS scan_filter package

### DIFF
--- a/ws/src/scan_filter/resource/scan_filter__front_cone
+++ b/ws/src/scan_filter/resource/scan_filter__front_cone
@@ -1,1 +1,0 @@
-front_cone

--- a/ws/src/scan_filter/setup.py
+++ b/ws/src/scan_filter/setup.py
@@ -12,10 +12,6 @@ setup(
             os.path.join("share/ament_index/resource_index/packages"),
             ["resource/" + package_name],
         ),
-        (
-            os.path.join("share/ament_index/resource_index/ros2_executable"),
-            ["resource/scan_filter__front_cone"],
-        ),
         (os.path.join("share", package_name), ["package.xml"]),
     ],
     install_requires=["setuptools", "rclpy"],


### PR DESCRIPTION
## Summary
- fix `scan_filter` packaging so ros2 can find its executable

## Testing
- `pre-commit run -a` *(fails: cannot fetch pre-commit-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68517d484d2c8323ba11de7bcfeebf07