### PR TITLE
Add teleop only mode

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,21 @@
+version: "3.5"
+
+services:
+  # ───── 1) Dormimos la navegación / explore_lite  ─────
+  navigation:
+    command: [ "bash", "-c", "echo 'explore_lite disabled by override'; sleep infinity" ]
+
+  # ───── 2) Añadimos teleop_twist_keyboard  ─────
+  teleop:
+    image: husarion/rosbot:humble-latest
+    network_mode: host
+    privileged: true
+    stdin_open: true
+    tty: true
+    environment:
+      - ROS_DOMAIN_ID=0
+    command: >
+      bash -c "
+        source /opt/ros/humble/setup.bash &&
+        ros2 run teleop_twist_keyboard teleop_twist_keyboard
+          cmd_vel:=/cmd_vel"

--- a/justfile
+++ b/justfile
@@ -138,3 +138,17 @@ _install-yq:
         chmod +x /usr/bin/yq
         echo "yq installed successfully!"
     fi
+teleop:
+    @echo "Starting sensors and teleop..."
+    # 1) Arranca todos los contenedores en segundo plano,
+    #    excepto los que duermen (navigation)
+    docker compose -f compose.yaml -f compose.override.yaml -f docker-compose.override.yml up -d
+    # 2) Muestra instrucciones y se adjunta a teleop
+    @echo "╭─────────────────────────────────────────────"
+    @echo "│  Controles:  W/S = avanzar/retroceder"
+    @echo "│              A/D = girar izquierda/derecha"
+    @echo "│              Q/E = giro suave"
+    @echo "│  Salir: Ctrl-P  Ctrl-Q   (deja el nodo vivo)"
+    @echo "╰─────────────────────────────────────────────"
+    docker attach teleop
+


### PR DESCRIPTION
## Summary
- allow launching sensors with teleoperation only
- add `docker-compose.override.yml` that disables navigation and starts `teleop_twist_keyboard`
- extend justfile with `teleop` target to start this mode

## Testing
- `pre-commit run --files justfile docker-compose.override.yml` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862b6bb158c83238e959093806f06e9