### PR TITLE
Update teleop/foxglove override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,15 +7,48 @@ services:
 
   # ───── 2) Añadimos teleop_twist_keyboard  ─────
   teleop:
-    image: husarion/rosbot:humble-latest
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
     privileged: true
     stdin_open: true
     tty: true
     environment:
       - ROS_DOMAIN_ID=0
+    depends_on:
+      - rosbot
     command: >
       bash -c "
         source /opt/ros/humble/setup.bash &&
         ros2 run teleop_twist_keyboard teleop_twist_keyboard
           cmd_vel:=/cmd_vel"
+
+  # ────────────────────────────────
+  # Puente ROS 2 ⇆ Foxglove WebSocket
+  # ────────────────────────────────
+  # UI web: sólo 8080 -> host
+  foxglove:
+    image: husarion/foxglove:studio
+    network_mode: bridge
+    ports:
+      - "8080:8080"
+    environment:
+      - DS_HOST=foxglove-ds
+      - DS_PORT=8765
+
+  # Bridge ROS <-> WebSocket
+  foxglove-ds:
+    image: husarion/foxglove-bridge:humble-0.7.3-20240108
+    network_mode: bridge
+    privileged: true
+    ports:
+      - "8765:8765"
+    environment:
+      - ROS_DOMAIN_ID=0
+    depends_on:
+      rosbot:
+        condition: service_healthy
+    command: >
+      ros2 launch foxglove_bridge foxglove_bridge_launch.xml
+        address:=0.0.0.0
+        port:=8765
+        use_compressed:=true


### PR DESCRIPTION
## Summary
- update `teleop` service image
- ensure `teleop` waits for the existing `rosbot`
- add Foxglove Studio service and WebSocket bridge

## Testing
- `pre-commit` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68656b4576448323937a8866cedc61ee